### PR TITLE
add scopes in config

### DIFF
--- a/config/bifrost.php
+++ b/config/bifrost.php
@@ -51,6 +51,8 @@ return [
         'token_uri'     => 'oauth/token',
         'userinfo_uri'  => 'api/user',
 
+        'scopes'        => [],
+
         'guzzle'        => [],
     ],
 ];

--- a/src/BifrostSocialiteProvider.php
+++ b/src/BifrostSocialiteProvider.php
@@ -2,6 +2,7 @@
 
 namespace EtsvThor\BifrostBridge;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Laravel\Socialite\Two\User;
 use Laravel\Socialite\Two\AbstractProvider;
@@ -13,12 +14,25 @@ class BifrostSocialiteProvider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = [''];
+    protected $scopes;
 
     /**
      * {@inheritdoc}
      */
     protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Request $request, $clientId, $clientSecret, $redirectUrl, $guzzle = [])
+    {
+        parent::__construct($request, $clientId, $clientSecret, $redirectUrl, $guzzle);
+
+        // get scopes from config and set them
+        $this->setScopes(
+            $this->getConfig('scopes', [])
+        );
+    }
 
     /**
      * Get the authentication URL for the provider.


### PR DESCRIPTION
- scopes in config
- custom error on failed login
- however, the GET parameters from the bifrost redirect are still visible in the url when the login fails