### PR TITLE
redirect to register option

### DIFF
--- a/config/bifrost.php
+++ b/config/bifrost.php
@@ -63,7 +63,7 @@ return [
         'token_uri'     => 'oauth/token',
         'userinfo_uri'  => 'api/user',
 
-        'register'      => false,
+        'intended'      => 'login',
 
         'scopes'        => [],
 

--- a/config/bifrost.php
+++ b/config/bifrost.php
@@ -63,6 +63,8 @@ return [
         'token_uri'     => 'oauth/token',
         'userinfo_uri'  => 'api/user',
 
+        'register'      => false,
+
         'scopes'        => [],
 
         'guzzle'        => [],

--- a/src/BifrostSocialiteProvider.php
+++ b/src/BifrostSocialiteProvider.php
@@ -2,6 +2,7 @@
 
 namespace EtsvThor\BifrostBridge;
 
+use EtsvThor\BifrostBridge\Enums\Intended;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Laravel\Socialite\Two\User;
@@ -34,9 +35,9 @@ class BifrostSocialiteProvider extends AbstractProvider
         );
     }
 
-    public function shouldRegister(bool $shouldRegister = true): self
+    public function intended(Intended $intended = null): self
     {
-        Arr::set($this->parameters, 'register', $shouldRegister);
+        Arr::set($this->parameters, 'intended', ($intended ?? Intended::default())?->value);
         return $this;
     }
 

--- a/src/BifrostSocialiteProvider.php
+++ b/src/BifrostSocialiteProvider.php
@@ -34,6 +34,12 @@ class BifrostSocialiteProvider extends AbstractProvider
         );
     }
 
+    public function shouldRegister(bool $shouldRegister = true): self
+    {
+        Arr::set($this->parameters, 'register', $shouldRegister);
+        return $this;
+    }
+
     /**
      * Get the authentication URL for the provider.
      *

--- a/src/Enums/Intended.php
+++ b/src/Enums/Intended.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EtsvThor\BifrostBridge\Enums;
+
+enum Intended: string
+{
+    case Login = 'login';
+    case Register = 'register';
+
+    public static function default(): self
+    {
+        return self::tryFrom(config('bifrost.service.intended')) ?? self::Login;
+    }
+}

--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -88,7 +88,9 @@ class LoginController
             return $this->resolveRedirect('bifrost.redirects.after_login');
         }
 
-        return Socialite::driver('bifrost')->redirect();
+        return Socialite::driver('bifrost')
+            ->shouldRegister($request->get('register', config('bifrost.service.register', false)))
+            ->redirect();
     }
 
     public function callback()

--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -3,7 +3,9 @@
 namespace EtsvThor\BifrostBridge\Http\Controllers;
 
 use Error;
+use EtsvThor\BifrostBridge\BifrostSocialiteProvider;
 use EtsvThor\BifrostBridge\Data\BifrostUserData;
+use EtsvThor\BifrostBridge\Enums\Intended;
 use EtsvThor\BifrostBridge\Events\BifrostLogin;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
@@ -88,8 +90,10 @@ class LoginController
             return $this->resolveRedirect('bifrost.redirects.after_login');
         }
 
+        $intended = $request->get('intended', config('bifrost.service.intended', 'login'));
+
         return Socialite::driver('bifrost')
-            ->shouldRegister($request->get('register', config('bifrost.service.register', false)))
+            ->intended(Intended::from($intended))
             ->redirect();
     }
 


### PR DESCRIPTION
By adding `register=1` to either the `login` route query parameters, the user is redirected to bifrost registration instead of bifrost login.

e.g. member database:
`subscribe instructions` -> `login` -> `bifrost registration` -> subscribe form

instead of having to click on `register` themselves on bifrost which is confusing